### PR TITLE
Use the hosted domain URL param to enforce heroku.com login

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,8 +58,9 @@ func authorize(s sessions.Store, h http.Handler) http.Handler {
 		}
 
 		o2c := newOauth2Config(r.Host)
+		hostedDomain := oauth2.SetAuthURLParam("hd", "heroku.com")
 
-		redirect := o2c.AuthCodeURL(config.StateToken, oauth2.AccessTypeOnline)
+		redirect := o2c.AuthCodeURL(config.StateToken, oauth2.AccessTypeOnline, hostedDomain)
 
 		session.Values["return_to"] = r.URL.RequestURI()
 		session.Save(r, w)


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context

<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

Google OIDC has a special param to lock logins to a certain domain. 
This can help when a user has multiple google profiles. 

https://developers.google.com/identity/protocols/OpenIDConnect#hd-param

# Solution

<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

Use `hd=heroku.com` in the redirect URL. 

# Testing

<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference

<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
https://salesforce-internal.slack.com/archives/G6ZMEFW6N/p1678130852797029
