### PR TITLE
Parse into slice

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type configuration struct {
 	ProxyURL              *url.URL `env:"PROXY_URL,default=http://localhost:8000/"`                 // URL to Proxy to
 	CallbackPath          string   `env:"CALLBACK_PATH,default=/auth/callback/google"`              // Callback URL
 	HealthCheckPath       string   `env:"HEALTH_CHECK_PATH,default=/en-US/static/html/credit.html"` // Health Check path in splunk, this path is proxied w/o auth. The default is a static file served by the splunk web server
-	EmailSuffix           string   `env:"EMAIL_SUFFIX,default=@heroku.com,@salesforce.com"`         // Required email suffix. Emails w/o this suffix will not be let in
+	EmailSuffix           string   `env:"EMAIL_SUFFIX,default=@heroku.com;@salesforce.com"`         // Required email suffix. Emails w/o this suffix will not be let in
 	StateToken            string   `env:"STATE_TOKEN,required"`                                     // Token used when communicating with Google Oauth2 provider
 }
 
@@ -94,7 +94,7 @@ func authorize(s sessions.Store, h http.Handler) http.Handler {
 }
 
 func suffixMismatch(email, emailSuffixString string) bool {
-	emailSuffixes := strings.Split(emailSuffixString, ",")
+	emailSuffixes := strings.Split(emailSuffixString, ";")
 
 	for _, emailSuffix := range emailSuffixes {
 		if strings.HasSuffix(email, emailSuffix) {

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func authorize(s sessions.Store, h http.Handler) http.Handler {
 	})
 }
 
-func suffixMismatch(email, emailSuffixString string) bool {
+func suffixMismatch(email string, emailSuffixString string) bool {
 	emailSuffixes := strings.Split(emailSuffixString, ";")
 
 	for _, emailSuffix := range emailSuffixes {


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context

This addresses what I pointed out in https://github.com/heroku/sproxy/pull/20#discussion_r1751579551. The default value is defined in a way where only part of it is being honored.

<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution

Expect a semicolon delimited configuration value and let `envdecode` handle the decoding.

To roll this out, `EMAIL_SUFFIX` will have to be updated to be semicolon delimited in production. That will cause a temporary inability to authenticate.

<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing

<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

This should be verified in staging.

# Reference

<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
https://github.com/heroku/sproxy/pull/20#discussion_r1751579551