### PR TITLE
add valid_time to check session time

### DIFF
--- a/fix-session-bug
+++ b/fix-session-bug
@@ -1,0 +1,1 @@
+branch 'fix-session-bug' set up to track 'origin/fix-session-bug'.

--- a/fix-session-bug
+++ b/fix-session-bug
@@ -1,1 +1,0 @@
-branch 'fix-session-bug' set up to track 'origin/fix-session-bug'.

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func newOauth2Config(host string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
-		RedirectURL:  "http://" + host + config.CallbackPath,
+		RedirectURL:  "https://" + host + config.CallbackPath,
 		Scopes:       []string{"https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile"},
 		Endpoint:     google.Endpoint,
 	}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ type configuration struct {
 	SessionValidTime      int      `env:"SESSION_VALID_TIME"`                                       // session valid time in minutes
 }
 
-// seconds
 var config configuration
 
 func newOauth2Config(host string) *oauth2.Config {
@@ -77,7 +76,7 @@ func authorize(s sessions.Store, h http.Handler) http.Handler {
 
 		session_valid_until, ok := session.Values["valid_until"]
 		if !ok {
-			log.Printf("Session expired: no valid_until field\n")
+			log.Printf("%s auth=failed msg='session expired: no valid_until field' redirect=%s\n", logPrefix, redirect)
 			http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
 			return
 		}
@@ -154,7 +153,6 @@ func handleGoogleCallback(s sessions.Store) http.Handler {
 		logPrefix := fmt.Sprintf("app=sproxy fn=callback method=%s path=%s\n",
 			r.Method, r.URL.Path)
 
-		log.Printf("request object %v", r.URL.RequestURI())
 		o2c := newOauth2Config(r.Host)
 
 		if v := r.FormValue("state"); v != config.StateToken {
@@ -255,5 +253,6 @@ func main() {
 
 	listen := host + ":" + port
 	log.Println("Listening on", listen)
+
 	log.Fatal(http.ListenAndServe(listen, nil))
 }


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
If a user authenticates with given URL, their browser receives a cookie which lasts beyond the browser tab (currently 30 days).

Expected behavior: after 30 days, the user is required to re-authenticate to URL via the SSO provider (Google)
Actual behavior: if the user continues using URL within the 30 day window, their cookie is refreshed and the expiry time is extended

We need reinforce auth after a session is expired.
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
Configuring session valid time and reinforce auth
<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
This was tested locally
<!--
This section describes how the code is tested, and should include at least
checkboxes for:

- [ ] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020qe1MYAQ/view
<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
