### PR TITLE
Update CODEOWNERS to only include observability team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @heroku/production-services @heroku/heroku-tools-pipelines
+* @heroku/observability
 #ECCN:Open Source


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
The CODEOWNERS file is out of date. It should only list the observabiltiy team as the codeowner. 
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
This pr updates the CODEOWNERS file.
<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
- [x] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration).
- [n/a] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).

# Reference
Updating old info I am tracking here: https://docs.google.com/spreadsheets/d/1yPfdqYLnirTF51o2ZTwiicF1SZOZxP7fvvSRyO_JSJY/edit?gid=0#gid=0
<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
