### PR TITLE
Remove unused .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: go
-install:
-  - npm install -g snyk
-script:
-- snyk test
-- snyk monitor --org=sr-tools


### PR DESCRIPTION
<!--
Supporting documentation for this Pull Request Template can be found here:
https://github.com/heroku/production-services/blob/master/docs/adr/2019-05-01-code-review-protocol.md#pull-request-templates
-->

# Context
This Travis CI is not in use. There is no Travis webhook in the repo's settings, the Snyk webhook in the repo's settings has never been used, and Snyk is now deprecated at Heroku. All CI/CD for this repo is handled via GIthub actions. We should get rid of this to clean up the repo.
<!--
This section describes the problem as well as relevant information necessary to
understand the problem. It can include links to external documentation if that
would help. Ideally, it should include enough information that someone with no
prior knowledge of the issue at hand will have a rudimentary understanding of
it after reading.
-->

# Solution
Remove the `.travis.yml` file. After the PR is merged, I will remove the Snyk webhook in GIthub actions.
<!--
This section describes the solution that was implemented to solve the problem.
Again, include as much detail as is necessary to explain how the solution works.
This may include describing API request/response protocols, environment
variables necessary to use the solution, etc.
-->

# Testing
- [x] spec tests (I'm not sure this is the right word, but I don't want to
      mandate unit vs functional vs integration). - 
- [ ] staging (Checking this box indicates that you have, in fact, deployed and
      executed the code in a staging environment).
-->

# Reference
No work item, just cleaning up cruft
<!--
This section is a link to the GUS issue related to this pull request. Ideally,
all pull requests should have a related issue. If there is no related issue,
indicate why not.
-->
